### PR TITLE
feat: added support for auth0 invitations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export interface Auth0StrategyOptions {
   scope?: Auth0Scope[] | string;
   audience?: string;
   organization?: string;
+  invitation?: string;
   connection?: string;
 }
 
@@ -76,6 +77,7 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
   private scope: Auth0Scope[];
   private audience?: string;
   private organization?: string;
+  private invitation?: string;
   private connection?: string;
   private fetchProfile: boolean;
 
@@ -101,6 +103,7 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
     this.scope = this.getScope(options.scope);
     this.audience = options.audience;
     this.organization = options.organization;
+    this.invitation = options.invitation;
     this.connection = options.connection;
     this.fetchProfile = this.scope
       .join(Auth0StrategyScopeSeperator)
@@ -125,6 +128,9 @@ export class Auth0Strategy<User> extends OAuth2Strategy<
     }
     if (this.organization) {
       params.set("organization", this.organization);
+    }
+    if (this.invitation) {
+      params.set("invitation", this.invitation);
     }
     if (this.connection) {
       params.set("connection", this.connection);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -169,6 +169,39 @@ describe(Auth0Strategy, () => {
     }
   });
 
+  test("should allow setting an invitation", async () => {
+    let strategy = new Auth0Strategy(
+      {
+        domain: "test.fake.auth0.com",
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+        scope: "custom",
+        audience: "SOME_AUDIENCE",
+        organization: "SOME_ORG",
+        invitation: "SOME_INVITATION",
+      },
+      verify,
+    );
+
+    let request = new Request("https://example.app/auth/auth0");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, BASE_OPTIONS);
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("invitation")).toBe(
+        "SOME_INVITATION",
+      );
+    }
+  });
+
   test("should allow setting the connection type", async () => {
     let strategy = new Auth0Strategy(
       {


### PR DESCRIPTION
When using auth0 organisations - you can opt to send users invitations to sign up via email, instead of creating users on their behalf first. They get an email with a link like so:

| Header | Header |
|--------|--------|
| Invitation link | https://0.0.0.0:8788/?invitation={foo}&organization={bar}&organization_name={baz}

Adding the invitation to the `/authorise` endpoint works as expected - [reference to the Auth0 doc](https://auth0.com/docs/api/authentication#authorization-code-flow-with-pkce)

| Param | Description |
|--------|--------|
| invitation | Ticket ID of the organization invitation. When inviting a member to an Organization, your application should handle invitation acceptance by forwarding the invitation and organization key-value pairs when the user accepts the invitation. | 

I've monkey patched it - and happy to send a video of it working e2e if you don't have 'organisations' available 
